### PR TITLE
Respect the header HTTP_X_FORWARDED_PROTO.

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -101,6 +101,7 @@ module Puma
     SERVER_PORT = "SERVER_PORT".freeze
     HTTP_HOST = "HTTP_HOST".freeze
     PORT_80 = "80".freeze
+    PORT_443 = "443".freeze
     LOCALHOST = "localhost".freeze
 
     SERVER_PROTOCOL = "SERVER_PROTOCOL".freeze

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -294,11 +294,11 @@ module Puma
           env[SERVER_PORT] = host[colon+1, host.bytesize]
         else
           env[SERVER_NAME] = host
-          env[SERVER_PORT] = default_server_host_port(env)
+          env[SERVER_PORT] = default_server_port(env)
         end
       else
         env[SERVER_NAME] = LOCALHOST
-        env[SERVER_PORT] = default_server_host_port(env)
+        env[SERVER_PORT] = default_server_port(env)
       end
 
       unless env[REQUEST_PATH]
@@ -322,7 +322,7 @@ module Puma
       env[REMOTE_ADDR] = client.peeraddr.last
     end
 
-    def default_server_host_port(env)
+    def default_server_port(env)
       env['HTTP_X_FORWARDED_PROTO'] == 'https' ? PORT_443 : PORT_80
     end
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -294,11 +294,11 @@ module Puma
           env[SERVER_PORT] = host[colon+1, host.bytesize]
         else
           env[SERVER_NAME] = host
-          env[SERVER_PORT] = PORT_80
+          env[SERVER_PORT] = default_server_host_port(env)
         end
       else
         env[SERVER_NAME] = LOCALHOST
-        env[SERVER_PORT] = PORT_80
+        env[SERVER_PORT] = default_server_host_port(env)
       end
 
       unless env[REQUEST_PATH]
@@ -320,6 +320,10 @@ module Puma
       # intermediary acting on behalf of the actual source client."
       #
       env[REMOTE_ADDR] = client.peeraddr.last
+    end
+
+    def default_server_host_port(env)
+      env['HTTP_X_FORWARDED_PROTO'] == 'https' ? PORT_443 : PORT_80
     end
 
     # Given the request +env+ from +client+ and a partial request body

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -125,4 +125,23 @@ class TestPumaServer < Test::Unit::TestCase
 
     assert_equal giant.bytesize, out.bytesize
   end
+
+  def test_respect_x_forwarded_proto
+    @server.app = proc do |env|
+      [200, {}, [env['SERVER_PORT']]]
+    end
+
+    @server.add_tcp_listener @host, @port
+    @server.run
+
+    req = Net::HTTP::Get.new("/")
+    req['HOST'] = "example.com"
+    req['X_FORWARDED_PROTO'] = "https"
+
+    res = Net::HTTP.start @host, @port do |http|
+      http.request(req)
+    end
+
+    assert_equal "443", res.body
+  end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -144,4 +144,22 @@ class TestPumaServer < Test::Unit::TestCase
 
     assert_equal "443", res.body
   end
+
+  def test_default_server_port
+    @server.app = proc do |env|
+      [200, {}, [env['SERVER_PORT']]]
+    end
+
+    @server.add_tcp_listener @host, @port
+    @server.run
+
+    req = Net::HTTP::Get.new("/")
+    req['HOST'] = "example.com"
+
+    res = Net::HTTP.start @host, @port do |http|
+      http.request(req)
+    end
+
+    assert_equal "80", res.body
+  end
 end


### PR DESCRIPTION
I just found out that if the host name in the header HTTP_HOST doesn't include a port number, puma sets it to 80 by default.

When a request is redirected from a web server using ssl, nginx for instance, it should respect the header HTTP_X_FORWARDED_PROTO to set the default server port.
Otherwise rack generates urls like `https://example.com:80/foo/bar` which are invalid.
